### PR TITLE
Create props objects for blocks from data-* attributes

### DIFF
--- a/lib/evil-blocks.js
+++ b/lib/evil-blocks.js
@@ -74,6 +74,29 @@
         }
     };
 
+
+    /**
+     * Read data properties for an element
+     */
+    var getPropertiesObject = function(el) {
+        var props = {};
+        var attributes = el.attributes ? el.attributes : el[0].attributes;
+
+        [].forEach.call(attributes, function(attribute) {
+            if (attribute.name.indexOf('data-') == 0 ) {
+                var propertyName    = attribute.name.substr(5);
+                propertyName        = propertyName.replace(/-(.)/g, function($0, $1) { return $1.toUpperCase(); });
+
+                if (propertyName != 'role' && propertyName != 'block') {
+                    props[propertyName] = attribute.value
+                }
+            }
+        });
+
+        return props;
+    };
+
+
     /**
      * Execute `callback` on every finded `selector` inside `base`.
      */
@@ -89,6 +112,8 @@
 
         for ( var i = 0; i < blocks.length; i++ ) {
             var block = $(blocks[i]);
+
+            block.props = getPropertiesObject(block);
 
             var vitalized = block.data('evil-vitalized');
             if ( !vitalized ) {
@@ -107,6 +132,7 @@
                 };
             })(block);
 
+
             var actives = { };
             block.find('[data-role]').each(function (_, el) {
                 var roles = el.attributes['data-role'].value.split(' ');
@@ -116,6 +142,7 @@
                         obj[role] = $();
                     }
                     obj[role].push(el);
+                    obj[role].props = getPropertiesObject(obj[role]);
                 }
             });
 

--- a/test/blocks.coffee
+++ b/test/blocks.coffee
@@ -136,6 +136,31 @@ describe 'evil.block', ->
       body '<div class="page"> <b data-role="roleName"/> </div>'
       prop.is('@roleName').should.be.true
 
+
+    it 'creates props object for block', ->
+      body """
+        <div class="page" data-foo="a" data-bar="b"></div>
+      """
+      data = null
+      evil.block '.page',
+        init: ->
+          data = @block.props
+      data.should.eql {foo: "a", bar: "b"}
+
+
+    it 'creates props object for elements', ->
+      body """
+        <div class="page">
+          <div data-role="element" data-foo="a" data-bar="b"></div>
+        </div>
+      """
+      data = null
+      evil.block '.page',
+        init: ->
+          data = @element.props
+      data.should.eql {foo: "a", bar: "b"}
+
+
     it 'listens block events', ->
       burning = ''
       evil.block '.page',


### PR DESCRIPTION
For this markup

``` slim
@@block data-property='foo' data-another-property='bar'
  @element data-property='baz'
```

these properties will be created

``` coffeescript
@block.props.property # 'foo'
@block.props.anotherProperty # 'bar'
@element.props.property # 'baz'
```
