### PR TITLE
evil-blocks.debug.js makes all the event listeners call the last callback function

### DIFF
--- a/lib/evil-blocks.debug.js
+++ b/lib/evil-blocks.debug.js
@@ -21,19 +21,22 @@
             var event = parts[0] ? parts[0] : parts[1];
 
             var callback = obj[name];
-            obj[name] = function (e) {
-                var source   = e.el ? e.el[0] : this.block[0];
-                var messages = ['Event "' + event + '" on', source];
 
-                var params = Array.prototype.slice.call(arguments, 1);
-                if ( params.length > 0 ) {
-                    messages.push('with params');
-                    messages = messages.concat(params);
+            (function(callback){
+                obj[name] = function (e) {
+                    var source   = e.el ? e.el[0] : this.block[0];
+                    var messages = ['Event "' + event + '" on', source];
+
+                    var params = Array.prototype.slice.call(arguments, 1);
+                    if ( params.length > 0 ) {
+                        messages.push('with params');
+                        messages = messages.concat(params);
+                    }
+
+                    log.apply(this, messages);
+                    callback.apply(this, arguments);
                 }
-
-                log.apply(this, messages);
-                callback.apply(this, arguments);
-            }
+            })(callback);
         }
     };
 


### PR DESCRIPTION
After switching on `evil-blocks.debug.js` all the events that were specified on a block were calling the function of the last specified event. Here is the [plunker](http://plnkr.co/edit/T7Q8lEBVJdaps7Vg8QIP?p=preview) that shows the problem. When I try to switch between radio buttons the `submit` event fires, but not `change` as it should.

This pull request fixes this issue.
