### PR TITLE
Fix incorrect event name in debugger

### DIFF
--- a/lib/evil-blocks.debug.js
+++ b/lib/evil-blocks.debug.js
@@ -22,7 +22,7 @@
 
             var callback = obj[name];
 
-            (function(callback){
+            (function(event, callback){
                 obj[name] = function (e) {
                     var source   = e.el ? e.el[0] : this.block[0];
                     var messages = ['Event "' + event + '" on', source];
@@ -36,7 +36,7 @@
                     log.apply(this, messages);
                     callback.apply(this, arguments);
                 }
-            })(callback);
+            })(event, callback);
         }
     };
 


### PR DESCRIPTION
I'm sorry but my previous pull-request #25 was incomplete. There is an issue when we had a name of the last specified event in console log, but not the real event name.

This pull-request resolves it.
