### PR TITLE
Check equality of current and delegate targets in block callback

### DIFF
--- a/lib/evil-blocks.js
+++ b/lib/evil-blocks.js
@@ -238,7 +238,7 @@
 
             (function (events, callback) {
                 obj.block.on(events, function (e) {
-                    if ( e.currentTarget == e.target ) {
+                    if ( e.currentTarget == e.delegateTarget ) {
                         callback.apply(obj, arguments);
                     }
                 });


### PR DESCRIPTION
In some cases, if I click on children element, old condition check equality of current bubbling element and clicked element.

In good case we need check equality of current bubbling element and delegate element.
