### PR TITLE
forEach (not supported by IE8) replaced with for loop

### DIFF
--- a/lib/evil-blocks.js
+++ b/lib/evil-blocks.js
@@ -76,9 +76,9 @@
         });
 
         return function () {
-            objects.forEach(function (obj) {
-                if (obj.init) obj.init();
-            })
+            for ( var i = 0; i < objects.length; i++ ) {
+                if (objects[i].init) objects[i].init();
+            }
         };
     };
 
@@ -161,9 +161,10 @@
         }
 
         var inits = [];
-        evil.block.defined.forEach(function (define) {
+        for ( var i = 0; i < evil.block.defined.length; i++ ) {
+            var define = evil.block.defined[i];
             inits.push( find(base, define[0], define[1], define[2]) );
-        });
+        }
 
         for ( var i = 0; i < inits.length; i++ ) {
             if ( inits[i] ) inits[i]();


### PR DESCRIPTION
forEach() javascript method (not supported by IE8 and older: http://j.mp/1t8vsfR) replaced with a simple for loop (supported by all browsers).
